### PR TITLE
Added "api_key" to more files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ rs.close()
 from prsaw import RandomStuff
 
 # initiate the object with async mode
-rs = RandomStuff(async_mode=True)
+api_key = "Your API Key"
+rs = RandomStuff(async_mode = True, api_key = api_key)
 
 # get a joke
 joke = await rs.get_joke()

--- a/prsaw/PRSAW.py
+++ b/prsaw/PRSAW.py
@@ -8,13 +8,13 @@ class RandomStuff(APIClient):
 
     Example Usage:
 
-        rs = RandomStuff()
+        rs = RandomStuff(api_key = "Your API Key")
         joke = rs.get_joke()
         print(joke)
         rs.close()
 
     Example async usage:
-        rs = RandomStuff(async_mode=True)
+        rs = RandomStuff(async_mode=True, api_key="Your API Key")
         joke = await rs.get_joke()
         print(joke)
         await rs.close()


### PR DESCRIPTION
I noticed after the version bump, the `api_key` kwarg was shown only in the blocking example. I added it to the async example in README.md and prsaw/PRSAW.py.