### PR TITLE
Add `aclose` method for httpx.AsyncClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ rs = RandomStuff(async_mode = True, api_key = api_key)
 # get a joke
 joke = await rs.get_joke()
 print(joke)
+
+# close the session
+await rs.aclose()
 ```
 
 
@@ -54,7 +57,7 @@ await get_image(_type = "any") # for all the endpoints
 await get_ai_response(msg)
 
 # others
-await close() # closes the object
+await aclose() # closes the object
  ```
  
  ## Important Links

--- a/prsaw/PRSAW.py
+++ b/prsaw/PRSAW.py
@@ -76,4 +76,9 @@ class RandomStuff(APIClient):
     _post_get_ai_response = _post_get_image
 
     def close(self):
+        """Closes a sync httpx client. For async usage, Use `RandomStuff.aclose()` method instead"""
         return self.session.close()
+    
+    async def aclose(self):
+        """Closes an Async httpx client. For normal usage, Use `RandomStuff.close()` method instead"""
+        return await self.session.aclose()

--- a/prsaw/PRSAW.py
+++ b/prsaw/PRSAW.py
@@ -52,6 +52,16 @@ class RandomStuff(APIClient):
 
     @endpoint
     def get_joke(self, _type: str = "any") -> dict:
+        """Gets a random joke
+        
+        Parameters:
+            - _type (str): The type of joke. Leave it or use `any` for a random type.
+                           Can be: ('dev', 'spooky', 'pun', 'any')
+        
+        Returns:
+            - str: The random joke
+        """
+        
         _type = _type.lower()
         if _type.lower() not in self._joke_types:
             raise RuntimeError("Unknown joke type provided: {}".format(_type))
@@ -60,6 +70,15 @@ class RandomStuff(APIClient):
 
     @endpoint
     def get_image(self, _type: str = "any") -> str:
+        """Gets a random image
+        
+        Parameters:
+            - _type (str): The type of joke. Use `any` for a random type.
+                           Can be: ('aww', 'duck', 'dog', 'cat', 'memes', 'dankmemes', 'holup', 'art', 'harrypottermemes', 'facepalm', 'any')
+        
+        Returns:
+            - str: The random joke
+        """
         _type = _type.lower()
         if _type not in self._image_types:
             raise RuntimeError("Unknown image type provided: {}".format(_type))
@@ -68,6 +87,15 @@ class RandomStuff(APIClient):
 
     @endpoint
     def get_ai_response(self, msg: str, *, lang="en") -> str:
+        """Gets random AI response
+        
+        Parameters:
+            - msg (str): The message on which the response is required.
+            - lang (str): The language in which response is required. It is `en` (English) by default.
+        
+        Returns:
+            - str : The random response.
+        """
         return Get("/ai/response", params={"message": msg, "language": lang})
 
     def _post_get_image(self, res):
@@ -78,7 +106,8 @@ class RandomStuff(APIClient):
     def close(self):
         """Closes a sync httpx client. For async usage, Use `RandomStuff.aclose()` method instead"""
         return self.session.close()
-    
+
     async def aclose(self):
         """Closes an Async httpx client. For normal usage, Use `RandomStuff.close()` method instead"""
         return await self.session.aclose()
+


### PR DESCRIPTION
This PR fixes the error:
```py
AttributeError: 'AsyncClient' object has no attribute 'close'
```

...by adding another method, `aclose` that closes the `httpx.AsyncClient` and is an async function.
